### PR TITLE
Add min width and hide UIs on sm/lg

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -22,8 +22,8 @@ export default function RootLayout({
       lang="en"
       className="transition duration-150 ease-out [color-scheme:dark]"
     >
-      <body className="flex h-screen items-center justify-center overflow-hidden">
-        <main>{children}</main>
+      <body className="min-w-xl min-h-xl flex h-screen items-center justify-center overflow-hidden">
+        <main className="hidden xl:block">{children}</main>
         <Token />
       </body>
     </html>

--- a/ui/token.tsx
+++ b/ui/token.tsx
@@ -6,7 +6,7 @@ const Token = () => {
   return (
     <iframe
       id="vertex-iframe"
-      className="h-screen w-screen"
+      className="min-w-xl h-screen w-screen"
       src="/v0/index.html"
     />
   );


### PR DESCRIPTION
This changes consent to have a minimal mobile experience while avoiding unclear glitches emerged while resizing on desktop devices. The UI are available only on larger windows, while smaller devices provide full focus on artwork.

Future issues might alter this first solution in favor of mobile UIs.